### PR TITLE
msm8916-common: Enforce RRO on framework-res

### DIFF
--- a/product/Framework.mk
+++ b/product/Framework.mk
@@ -1,0 +1,2 @@
+PRODUCT_ENFORCE_RRO_TARGETS := \
+framework-res


### PR DESCRIPTION
Overlays only for framework-res will be converted into RROs.

Other overlays can't be converted due to some known issues on app RRO.